### PR TITLE
Add hand and deck privacy controls

### DIFF
--- a/src/definition.xml
+++ b/src/definition.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<game name="Standard Playing Cards" id="8f437fff-fc8f-4abf-a2e6-f77ebff2ac6d" octgnVersion="3.1.0.0" version="2.0.0.3" 
-    markersize="25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" tags="cards standard" description="Standard playing cards" setsurl="http://www.octgn.net" 
+<game name="Standard Playing Cards" id="8f437fff-fc8f-4abf-a2e6-f77ebff2ac6d" octgnVersion="3.1.0.0" version="2.0.0.4" 
+    markersize="25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" tags="cards standard" description="Standard playing cards with hand and deck privacy controls" setsurl="http://www.octgn.net" 
 	gameurl="http://www.octgn.net" authors="brine, magnus, kelly elton" iconurl="https://raw.github.com/kellyelton/Standard-Playing-Cards-Octgn/master/src/images/icon.jpg" scriptVersion="3.1.0.1">
     <scripts>
       <script src="scripts/actions.py" />
@@ -10,6 +10,7 @@
     <globalvariables>
         <globalvariable name="dealer" value="1"/>
     </globalvariables>
+    
     <card back="cards/back.png" front="cards/front.png" width="63" height="88" cornerRadius="0">
         <property name="Suit" type="String" textKind="Tokens" />
         <property name="Rank" type="String" textKind="Tokens" />
@@ -27,6 +28,18 @@
         <groupaction menu="SSStatus" shortcut="ctrl+alt+s"  execute="ssstatus" />
         <groupaction menu="Become Dealer" shortcut="ctrl+B" execute="becomedealer" />
         <groupaction menu="Who's Dealer?" execute="whosdealer" />
+        <groupaction menu="Hand Privacy" showExecute="return True">
+            <groupaction menu="Allow Others to View My Hand" execute="setHandProtectionAllow" />
+            <groupaction menu="Block Others from Viewing My Hand" execute="setHandProtectionBlock" />
+            <groupaction menu="Ask Permission to View My Hand" execute="setHandProtectionAsk" />
+            <groupaction menu="Check My Hand Privacy Setting" execute="checkHandProtection" />
+        </groupaction>
+        <groupaction menu="Deck Privacy" showExecute="return True">
+            <groupaction menu="Allow Others to View Deck" execute="setDeckProtectionAllow" />
+            <groupaction menu="Block Others from Viewing Deck" execute="setDeckProtectionBlock" />
+            <groupaction menu="Ask Permission to View Deck" execute="setDeckProtectionAsk" />
+            <groupaction menu="Check Deck Privacy Setting" execute="checkDeckProtection" />
+        </groupaction>
         <cardaction menu="Turn card Sideways" default="True" execute="tap" />
         <cardaction menu="Flip Card" shortcut="ctrl+f" execute="flip" />
         <cardaction menu="Discard Card" shortcut="del" execute="discard" />
@@ -38,12 +51,12 @@
    <player summary="Hand:{#Hand} Score:{#Score}">
     <globalvariable name="standing" value="1" />
     <counter name="Score" icon="counters/score.png" />
-    <hand name="Hand" shortcut="ctrl+H" visibility="me" ordered="False" width="63" height="88" icon="groups/hand.png">
+    <hand name="Hand" shortcut="ctrl+H" visibility="me" ordered="False" width="63" height="88" icon="groups/hand.png" protectionState="ask">
        <cardaction menu="Discard Card" shortcut="del" execute="discard" />
     </hand>
   </player>
   <shared>
-    <group name="Deck" shortcut="ctrl+E" visibility="none" width="63" height="88" icon="groups/deck.png">
+    <group name="Deck" shortcut="ctrl+E" visibility="none" width="63" height="88" icon="groups/deck.png" protectionState="ask">
         <groupaction menu="Deal X Cards" default="True" execute="dealMany" />
         <groupaction menu="Deal X Cards To Table" execute="dealManyToTable" />
         <groupaction menu="Deal X Cards To Table(face down)" execute="dealManyToTableDown" />

--- a/src/scripts/actions.py
+++ b/src/scripts/actions.py
@@ -186,3 +186,62 @@ def removemarker(card, x = 0, y = 0):
     mute()
     card.markers[StandardMarker] -= 1
     notify("{} removes a marker from {}.".format(me, card))
+
+# Group Protection Privacy Controls
+def setHandProtectionAsk(group, x = 0, y = 0):
+    """Require others to ask permission before viewing your hand"""
+    mute()
+    me.hand.protectionState = "ask" 
+    notify("{} now requires permission to view their hand.".format(me))
+
+def setHandProtectionAllow(group, x = 0, y = 0):
+    """Allow others to freely view your hand"""
+    mute()
+    me.hand.protectionState = "false"
+    notify("{} allows others to freely view their hand.".format(me))
+
+def setHandProtectionBlock(group, x = 0, y = 0):
+    """Prevent others from viewing your hand"""
+    mute()
+    me.hand.protectionState = "true"
+    notify("{} has blocked others from viewing their hand.".format(me))
+
+def setDeckProtectionAsk(group, x = 0, y = 0):
+    """Require others to ask permission before viewing the deck"""
+    mute()
+    shared.Deck.protectionState = "ask"
+    notify("{} set the deck to require permission to view.".format(me))
+
+def setDeckProtectionAllow(group, x = 0, y = 0):
+    """Allow others to freely view the deck"""
+    mute()
+    shared.Deck.protectionState = "false"
+    notify("{} allows others to freely view the deck.".format(me))
+
+def setDeckProtectionBlock(group, x = 0, y = 0):
+    """Prevent others from viewing the deck"""
+    mute()
+    shared.Deck.protectionState = "true"
+    notify("{} has blocked others from viewing the deck.".format(me))
+
+def checkHandProtection(group, x = 0, y = 0):
+    """Check your current hand privacy setting"""
+    mute()
+    state = me.hand.protectionState
+    if state == "ask":
+        notify("{}'s hand: Others must ask permission to view".format(me))
+    elif state == "true":
+        notify("{}'s hand: Viewing blocked".format(me))
+    else:
+        notify("{}'s hand: Open for all to view".format(me))
+
+def checkDeckProtection(group, x = 0, y = 0):
+    """Check current deck privacy setting"""
+    mute()
+    state = shared.Deck.protectionState
+    if state == "ask":
+        notify("Deck: Others must ask permission to view")
+    elif state == "true":
+        notify("Deck: Viewing blocked")
+    else:
+        notify("Deck: Open for all to view")


### PR DESCRIPTION
- Add protectionState='ask' to Hand and Deck groups by default
- Add Hand Privacy and Deck Privacy menu options for users
- Include functions to programmatically control privacy settings
- Allow, Block, and Ask Permission modes for both hand and deck
- Update game version to 2.0.0.4 with privacy control description
- Enhance gameplay with strategic information control options